### PR TITLE
ci: publish workflow for container images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,313 @@
+name: publish
+
+on:
+  push:
+    branches: ['main']
+    tags: ['v*.*.*']
+
+concurrency: ${{ github.ref }}
+
+env:
+  DOCKER_IMAGE_NAME: blinklabs/hydra-node
+  GHCR_IMAGE_NAME: ghcr.io/blinklabs-io/hydra-node
+
+jobs:
+
+  build-amd64:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: blinklabs
+          password: ${{ secrets.DOCKER_PASSWORD }} # uses token
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ runner.arch }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-buildx-
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKER_IMAGE_NAME }}
+            ${{ env.GHCR_IMAGE_NAME }}
+          flavor: |
+            latest=false
+            suffix=-amd64
+          tags: |
+            # Only version, no revision
+            type=match,pattern=v(.*)-(.*),group=1
+            # branch
+            type=ref,event=branch
+            # semver
+            type=semver,pattern={{version}}
+      - name: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      # TEMP fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      # TEMP fix
+      # Something strange is happening with the manifests when we push which
+      # breaks the downstream multi-arch-manifest, so pull and push to work
+      # around this by resubmitting manifests
+      - name: pull-and-push
+        run: |
+          for t in `echo '${{ steps.meta.outputs.tags }}'`; do
+            docker pull $t && docker push $t
+          done
+
+  build-arm64:
+    runs-on: ["self-hosted", "ARM64"]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: blinklabs
+          password: ${{ secrets.DOCKER_PASSWORD }} # uses token
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ runner.arch }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-buildx-
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKER_IMAGE_NAME }}
+            ${{ env.GHCR_IMAGE_NAME }}
+          flavor: |
+            latest=false
+            suffix=-arm64v8
+          tags: |
+            # Only version, no revision
+            type=match,pattern=v(.*)-(.*),group=1
+            # branch
+            type=ref,event=branch
+            # semver
+            type=semver,pattern={{version}}
+      - name: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      # TEMP fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      # TEMP fix
+      # Something strange is happening with the manifests when we push which
+      # breaks the downstream multi-arch-manifest, so pull and push to work
+      # around this by resubmitting manifests
+      - name: pull-and-push
+        run: |
+          for t in `echo '${{ steps.meta.outputs.tags }}'`; do
+            docker pull $t && docker push $t
+          done
+
+  multi-arch-manifest:
+    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: blinklabs
+          password: ${{ secrets.DOCKER_PASSWORD }} # uses token
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta-dockerhub
+        name: Metadata - Docker Hub
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            # Only version, no revision
+            type=match,pattern=v(.*)-(.*),group=1
+            # branch
+            type=ref,event=branch
+            # semver
+            type=semver,pattern={{version}}
+      - id: meta-dockerhub-tag
+        name: Metadata - Docker Hub (Tags)
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKER_IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            # Only version, no revision
+            type=match,pattern=v(.*)-(.*),group=1
+      - id: meta-ghcr
+        name: Metadata - GHCR
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.GHCR_IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            # Only version, no revision
+            type=match,pattern=v(.*)-(.*),group=1
+            # branch
+            type=ref,event=branch
+            # semver
+            type=semver,pattern={{version}}
+      - id: meta-ghcr-tag
+        name: Metadata - GHCR (Tags)
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            # Only version, no revision
+            type=match,pattern=v(.*)-(.*),group=1
+
+      # First, create manifests and push to GHCR
+
+      # Manifest for either branch or semver
+      - name: manifest-ghcr
+        run: |
+          for t in `echo '${{ steps.meta-ghcr.outputs.tags }}'`; do
+            docker manifest create ${t} --amend ${t}-amd64 --amend ${t}-arm64v8
+          done
+      # Optional manifest for tag versions (includes revisions)
+      - name: manifest-ghcr-tags
+        run: |
+          for t in `echo '${{ steps.meta-ghcr-tag.outputs.tags }}'`; do
+            docker manifest create ${t} --amend ${t}-amd64 --amend ${t}-arm64v8
+            docker manifest create ${{ env.GHCR_IMAGE_NAME }}:latest --amend ${t}-amd64 --amend ${t}-arm64v8
+          done
+        if: startsWith(github.ref, 'refs/tags/') && ! contains(github.ref, '-pre-')
+      # Push various manifests
+      - name: push-ghcr
+        run: |
+          for t in `echo '${{ steps.meta-ghcr.outputs.tags }}'`; do
+            docker manifest push ${t}
+          done
+      - name: push-ghcr-tags
+        run: |
+          docker manifest push ${{ env.GHCR_IMAGE_NAME }}:latest
+          for t in `echo '${{ steps.meta-ghcr-tag.outputs.tags }}'`; do
+            docker manifest push ${t}
+          done
+        if: startsWith(github.ref, 'refs/tags/') && ! contains(github.ref, '-pre-')
+
+      # Now, create manifests for Docker Hub
+
+      - name: manifest-dockerhub
+        run: |
+          for t in `echo '${{ steps.meta-dockerhub.outputs.tags }}'`; do
+            docker manifest create ${t} --amend ${t}-amd64 --amend ${t}-arm64v8
+          done
+      - name: manifest-dockerhub-tags
+        run: |
+          for t in `echo '${{ steps.meta-dockerhub-tag.outputs.tags }}'`; do
+            docker manifest create ${t} --amend ${t}-amd64 --amend ${t}-arm64v8
+            docker manifest create ${{ env.DOCKER_IMAGE_NAME }}:latest --amend ${t}-amd64 --amend ${t}-arm64v8
+          done
+        if: startsWith(github.ref, 'refs/tags/') && ! contains(github.ref, '-pre-')
+      - name: push-dockerhub
+        run: |
+          for t in `echo '${{ steps.meta-dockerhub.outputs.tags }}'`; do
+            docker manifest push ${t}
+          done
+      - name: push-dockerhub-tags
+        run: |
+          docker manifest push ${{ env.DOCKER_IMAGE_NAME }}:latest
+          for t in `echo '${{ steps.meta-dockerhub-tag.outputs.tags }}'`; do
+            docker manifest push ${t}
+          done
+        if: startsWith(github.ref, 'refs/tags/') && ! contains(github.ref, '-pre-')
+
+      # Update Docker Hub from README
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: blinklabs
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ env.DOCKER_IMAGE_NAME }}
+          readme-filepath: ./README.md
+          short-description: "Hydra Node built from source on Debian"
+
+  github-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: [multi-arch-manifest]
+    steps:
+      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+      - uses: actions/github-script@v7
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.repos.createRelease({
+                draft: false,
+                generate_release_notes: true,
+                name: process.env.RELEASE_TAG,
+                owner: context.repo.owner,
+                prerelease: ${{ (startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-pre-')) && true || false }},
+                repo: context.repo.repo,
+                tag_name: process.env.RELEASE_TAG,
+              });
+            } catch (error) {
+              core.setFailed(error.message);
+            }


### PR DESCRIPTION
This was created w/ `s/cardano-node/hydra-node/g` using our docker-cardano-node repo's publish workflow.