### PR TITLE
feat: hydra 2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,33 @@
+ARG RUST_ACCUMULATOR_REV=e5f6cfc13b075282fc0580700a66ce693c5d2d53
+
+FROM rust:1-bookworm AS rust-accumulator-build
+ARG RUST_ACCUMULATOR_REV
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+RUN git clone https://github.com/cardano-scaling/rust-accumulator.git \
+    && cd rust-accumulator \
+    && git checkout ${RUST_ACCUMULATOR_REV} \
+    && cd rust_accumulator \
+    && cargo build --release --locked \
+    && mkdir -p /opt/rust-accumulator/include /opt/rust-accumulator/lib/pkgconfig \
+    && cp -p target/release/librust_accumulator.a /opt/rust-accumulator/lib/ \
+    && cp -p ../include/rust_accumulator.h /opt/rust-accumulator/include/ \
+    && printf "prefix=/usr/local\nlibdir=\${prefix}/lib\nincludedir=\${prefix}/include\n\nName: librust_accumulator\nDescription: Rust Accumulator Library\nVersion: 0.1.0\nLibs: -L\${libdir} -lrust_accumulator\nCflags: -I\${includedir}\n" > /opt/rust-accumulator/lib/pkgconfig/librust_accumulator.pc
+
 FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-3 AS hydra-node-build
 # Install hydra-node
-ARG NODE_VERSION=1.2.1
+ARG NODE_VERSION=2.2.0
 ENV NODE_VERSION=${NODE_VERSION}
 RUN echo "Building tags/${NODE_VERSION}..." \
     && echo tags/${NODE_VERSION} > /CARDANO_BRANCH \
-    && git clone https://github.com/input-output-hk/hydra.git \
+    && git clone https://github.com/cardano-scaling/hydra.git \
     && cd hydra \
     && git tag \
     && git checkout tags/${NODE_VERSION} \
     && echo "with-compiler: ghc-${GHC_VERSION}" >> cabal.project.local \
     && echo "tests: False" >> cabal.project.local \
     && cabal update
-RUN apt-get update -y && apt-get install -y libsnappy-dev protobuf-compiler etcd-server
+RUN apt-get update -y && apt-get install -y etcd-server libsnappy-dev protobuf-compiler
+COPY --from=rust-accumulator-build /opt/rust-accumulator/ /usr/local/
 RUN cd hydra \
     && cabal build hydra-node \
     && mkdir -p /root/.local/bin/ \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `hydra-node` to 2.2.0 from the `cardano-scaling/hydra` repo and add a Rust build stage to bundle `librust_accumulator` for 2.2.x. The image now includes `etcd-server`, `libsnappy-dev`, and `protobuf-compiler`, and exposes accumulator headers and a pkg-config file for linking.

<sup>Written for commit a0efc9171386b25a3ab6074b78104494a7a52bed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/docker-hydra-node/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

